### PR TITLE
better error handling for the init container

### DIFF
--- a/init-container/index.js
+++ b/init-container/index.js
@@ -35,7 +35,11 @@ const getBarerToken = async () => {
 
 const decryptFile = async (httpClient, filePath) => {
     var encryptedContent = await readFileAsync(program.encryptedFolder + '/' + filePath, "utf8");
+    try {
     const response = await httpClient.post('/api/v1/decrypt', {data: encryptedContent});
+    } catch (e) {
+      throw new Error(`request to decrypt API failed: ${e.response ? e.response.status : error.message}`)
+    }
     return response.data;
 }
 
@@ -68,6 +72,7 @@ async function innerRun() {
     {
         secrets[file] = await decryptFile(httpClient, file);
     }
+    
     const outputFile = path.join(program.decryptedPath, program.decryptedFileName);
     console.log(`Writing output format using ${program.outputFormat} format to file ${outputFile}`);
 

--- a/init-container/index.js
+++ b/init-container/index.js
@@ -36,7 +36,8 @@ const getBarerToken = async () => {
 const decryptFile = async (httpClient, filePath) => {
     var encryptedContent = await readFileAsync(program.encryptedFolder + '/' + filePath, "utf8");
     try {
-    const response = await httpClient.post('/api/v1/decrypt', {data: encryptedContent});
+      const response = await httpClient.post('/api/v1/decrypt', {data: encryptedContent});
+      return response.data;
     } catch (e) {
       throw new Error(`request to decrypt API failed: ${e.response ? e.response.status : error.message}`)
     }

--- a/init-container/package.json
+++ b/init-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "init-decryptor",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Meant to be used inside init container to read encrypted values from a given folder and decrypt to them into a json in a given folder",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Replying to some complains from users that the error log is not informative enough.
Currently when decrypt API returns 400 the user see:
`Failed to run init container: Error: Request failed with status code 400`
After the change:
`Failed to run init container: Error: request to decrypt API failed: 400`

closes #103 