### PR TITLE
don't pass verbose to caporal

### DIFF
--- a/cli/lib/actions/encrypt.js
+++ b/cli/lib/actions/encrypt.js
@@ -14,7 +14,7 @@ const pjson = require('../../package.json');
 const DEFAULT_ENCODING = 'utf8';
 
 module.exports = async (args, options, logger) => {
-
+    
     const { serviceAccount, namespace } = options;
     logger.info('Encryption started...');
     logger.info('service account:', serviceAccount);

--- a/cli/lib/index.js
+++ b/cli/lib/index.js
@@ -20,6 +20,8 @@ const logger = new ColorfulChalkLogger('kamus-cli', {
   colorful: true, 
 }, process.argv);
 
+// remove the log levels before running caporal
+process.argv = process.argv.filter(x => (x != '--log-level' && x != 'debug'));
 
 prog
   .logger(logger)

--- a/cli/lib/index.js
+++ b/cli/lib/index.js
@@ -7,21 +7,11 @@ const regexGuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[
 
 const { ColorfulChalkLogger, INFO } = require('colorful-chalk-logger');
 
-// translate to ColorfulChalkLogger log level
-if (process.argv.indexOf('--verbose')) {
-  process.argv = process.argv.filter(arg => arg != '--verbose');
-  process.argv.push('--log-level');
-  process.argv.push('debug');
-}
-
 const logger = new ColorfulChalkLogger('kamus-cli', {
   level: INFO,
   date: false,
   colorful: true, 
-}, process.argv);
-
-// remove the log levels before running caporal
-process.argv = process.argv.filter(x => (x != '--log-level' && x != 'debug'));
+}, process.argv.indexOf('--verbose') > -1 ? process.argv.concat(new ['--log-level', 'debug']) : process.argv); // translate to ColorfulChalkLogger log level
 
 prog
   .logger(logger)

--- a/cli/lib/index.js
+++ b/cli/lib/index.js
@@ -13,6 +13,8 @@ const logger = new ColorfulChalkLogger('kamus-cli', {
   colorful: true, 
 }, process.argv.indexOf('--verbose') > -1 ? process.argv.concat(new ['--log-level', 'debug']) : process.argv); // translate to ColorfulChalkLogger log level
 
+process.argv.filter(x => x == 'verbose'); // ColorfulChalkLogger got the verbose, don't pass it to caporal
+
 prog
   .logger(logger)
   .version(pjson.version)

--- a/cli/lib/index.js
+++ b/cli/lib/index.js
@@ -5,18 +5,21 @@ const prog = require('caporal');
 const encrypt = require('./actions/encrypt');
 const regexGuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-const { ColorfulChalkLogger, DEBUG } = require('colorful-chalk-logger');
- 
-const logger = new ColorfulChalkLogger('kamus-cli', {
-  level: DEBUG,   // the default value is INFO
-  date: false,    // the default value is false.
-  colorful: true, // the default value is true.
-}, process.argv);
+const { ColorfulChalkLogger, INFO } = require('colorful-chalk-logger');
 
-// ColorfulChalkLogger takes care of the verbosity, we don't want to pass it to caporal
+// translate to ColorfulChalkLogger log level
 if (process.argv.indexOf('--verbose')) {
   process.argv = process.argv.filter(arg => arg != '--verbose');
+  process.argv.push('--log-level');
+  process.argv.push('debug');
 }
+
+const logger = new ColorfulChalkLogger('kamus-cli', {
+  level: INFO,
+  date: false,
+  colorful: true, 
+}, process.argv);
+
 
 prog
   .logger(logger)
@@ -36,7 +39,6 @@ prog
   .option('--secret-file-encoding <fileEncoding>', 'Encoding of secret file', prog.STRING)
   .option('-o, --output <outputFile>', 'Output to file', prog.STRING)
   .option('-O, --overwrite', 'Overwrites file if it already exists', prog.BOOL)
-  .option('--log-level <debug|verbose|info|warn|error|fatal>', 'log level', prog.STRING)
   .option('--log-flag <date|inline|colorful|no-date|no-inline|no-colorful>', 'log format', prog.STRING)
   .option('--log-output <filepath>', 'output log to file', prog.STRING)
   .option('--log-encoding <encoding>', 'log file encoding');

--- a/cli/lib/index.js
+++ b/cli/lib/index.js
@@ -13,6 +13,11 @@ const logger = new ColorfulChalkLogger('kamus-cli', {
   colorful: true, // the default value is true.
 }, process.argv);
 
+// ColorfulChalkLogger takes care of the verbosity, we don't want to pass it to caporal
+if (process.argv.indexOf('--verbose')) {
+  process.argv = process.argv.filter(arg => arg != '--verbose');
+}
+
 prog
   .logger(logger)
   .version(pjson.version)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soluto-asurion/kamus-cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "CLI Tool to encrypt secrets for kamus",
   "main": "index.js",
   "scripts": {

--- a/cli/test/encrypt.spec.js
+++ b/cli/test/encrypt.spec.js
@@ -10,6 +10,7 @@ const encrypt = require('../lib/actions/encrypt');
 
 const logger =
 {
+    debug: sinon.spy(),
     info: sinon.spy(),
     error: sinon.spy(),
     warn: sinon.spy(),


### PR DESCRIPTION
Closes #131 

caporal, our CLI manager, requires winston compatible logger, and we use ColorfulChalkLogger which isn't.
If we pass the `--verbose` parameter to `caporal` we receive an error.

ColorfulChalkLogger generates beautiful outputs and we currently don't want to replace it, this is a workaround to prevent caporal from getting the `--verbose` parameter.
