### PR TITLE
use local cli files when building docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,7 @@ jobs:
       - run:
           name: Build docker image
           working_directory: "cli"
-          command: docker build . --build-arg CLI_VERSION=$CLI_DOCKER_TAG -t soluto/kamus-cli:$CLI_DOCKER_TAG
+          command: docker build . -t soluto/kamus-cli:$CLI_DOCKER_TAG
       - run:
           name: Docker push
           command: |

--- a/cli/.dockerignore
+++ b/cli/.dockerignore
@@ -1,5 +1,6 @@
 node_modules
 .dockerignore
 Dockerfile
+test
 npm-debug.log
 .git

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:10-alpine
-ARG CLI_VERSION=0.0.7
-RUN yarn global add @soluto-asurion/kamus-cli@${CLI_VERSION}
 
-ENTRYPOINT ["kamus-cli"]
+WORKDIR /app
+COPY . .
+RUN yarn
+
+ENTRYPOINT ["node", "lib/index.js"]


### PR DESCRIPTION
When I've added the automatic docker CLI build upon master merge I've introduced a bug.
Currently, we publish the CLI to npmjs manually, it could take some time after the merge, meaning, when circle will try to build the Docker CLI, the CLI version will probably won't be available in npmjs yet.

The new approach is to build the Docker CLI from the local CLI files instead.