### PR TITLE
added regression tests

### DIFF
--- a/tests/integration/AwsKeyManagementTests.cs
+++ b/tests/integration/AwsKeyManagementTests.cs
@@ -32,6 +32,18 @@ namespace integration
             var sa = "sa:namespace";
             var data = "data";
             var encrypted = await mAwsKeyManagement.Encrypt(data, sa);
+
+            var decrypted = await mAwsKeyManagement.Decrypt(encrypted, sa);
+
+            Assert.Equal(data, decrypted);
+        }
+
+        [Fact]
+        public async Task RegressionTest()
+        {
+            var sa = "sa:namespace";
+            var data = "data";
+            var encrypted = "env$AQIDAHizI6sed7zuuIsC3swHqi0UTTDv7X15xoyC5QG9deKqMwHEoOhAcGhmWHDZ0naCQQ6lAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMGK6qLAGscq77QeC7AgEQgDuxpshMWysHf2mXmCDlFCdOKjFiGIIJvYNdJIuZCOfYZGXokLN77e+OS/ecob+SnCRRYYPMwGGWNBilYg==$o3t8Q+fpxvM+BuDID3ssqw==:2sutg2A6bmpDctVXaqDl4A==";
             var decrypted = await mAwsKeyManagement.Decrypt(encrypted, sa);
 
             Assert.Equal(data, decrypted);

--- a/tests/integration/AzureKeyVaultIntegrationTests.cs
+++ b/tests/integration/AzureKeyVaultIntegrationTests.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Extensions.Configuration;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Xunit;
 
 namespace integration
@@ -67,14 +66,25 @@ namespace integration
             var serviceAccountId = "default:default:";
 
             var encryptedData = await mAzureKeyManagement.Encrypt(data, serviceAccountId);
+            
+            var decryptedData = await mAzureKeyManagement.Decrypt(encryptedData, serviceAccountId);
 
-            InitializeKeyManagement();
+            Assert.Equal(data, decryptedData);
+        }
+
+        [Fact]
+        public async Task RegressionTest()
+        {
+            var data = "test";
+            var serviceAccountId = "default:default:";
+
+            var encryptedData = "JFmV3jXtdTR02BQxRUVE/1fDYOIZ7y7xxN6fBROb5WO40LP6f3dgbKYXyR9XnzRXcPaejsVmaHg8j6X2qSCTi771MC90qtpnpygX/P5AWQT6BkblA/vA8qHRSh5k7atUSo81QwE2kEEilEHMB57pl5S4t0Zo7amSYQGOlEp/8Dohq74AbKlhWHvUPqfcr/7LO4mhr7IqzcacuarLTyeRBZQklIqXGo1jn7eREa6/Th2eo8PH1yJHu9WRpyizzE1+y4Wk/EPQ2MquImZu3vSUdeZMy7IhtVNDoJbEdSi8dfjwg3VXWwdAR+cUx516QC1LmXuPsE3pMupi95XSo0GBCg==";
 
             var decryptedData = await mAzureKeyManagement.Decrypt(encryptedData, serviceAccountId);
 
             Assert.Equal(data, decryptedData);
         }
-        
+
         private string ComputeKeyId(string serviceUserName)
         {
             return 

--- a/tests/integration/EnvelopeDecoratorIntegrationTests.cs
+++ b/tests/integration/EnvelopeDecoratorIntegrationTests.cs
@@ -1,9 +1,7 @@
-using System;
 using System.Threading.Tasks;
 using Kamus.KeyManagement;
 using Microsoft.Azure.KeyVault;
 using Microsoft.Extensions.Configuration;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Xunit;
 
 namespace integration
@@ -43,11 +41,20 @@ namespace integration
             var randomString = new string('*', 16);
             var encryptedData = await mDecorator.Encrypt(randomString, "a-service-account");
             Assert.Contains("env$", encryptedData);
-
-            InitializeKeyManagement(); // reset the key management services to simulate new call to decrypt
-                
+                            
             var decryptedString = await mDecorator.Decrypt(encryptedData, "a-service-account");
             
+            Assert.Equal(randomString, decryptedString);
+        }
+
+        [Fact]
+        public async Task RegressionTest()
+        {
+            var randomString = new string('*', 16);
+            var encryptedData = "env$Ux2a2llsVdGY5/FsQ+G79A0WJfvjzddXS2jQk+hkY7zzJh6k29Kezkg12M6OorA0cYA7nXByBAOilNRbIWsE2+36ygCeqZg8PUMxBDPGOVE4ANYI+3abrl4aXmUSIy8uDrbISdl4RCVhwFNO2BCgecwioNv5mFGNzonELR1FcX1cLShezibWJehcptPExFM9Sey+GcXixPS2Fi6IivgTjzwFqHMze20wLlDFPkiFHN9CcUsHOt9ntxUFujtaMpZTJecTvXnhwknQOqQ3KNBBWyOgX65Svm45f4YEP5WZmdvF2mBSHTdkQ7AkfKZZV15p4dN1mzxs3raHTR2Qp366Sg==$nzx0kjzDxQ/d4rYfDUfBhw==:BSRpNCPL7R3uKFanSnjUw2E55xXcqIHvMRKWC1e+zVU=";
+
+            var decryptedString = await mDecorator.Decrypt(encryptedData, "a-service-account");
+
             Assert.Equal(randomString, decryptedString);
         }
     }

--- a/tests/integration/GoogleCloudKeyManagmentTests.cs
+++ b/tests/integration/GoogleCloudKeyManagmentTests.cs
@@ -67,5 +67,17 @@ namespace integration
             Assert.Equal(data, decrypted);
 
         }
+
+        [Fact]
+        public async Task RegresssionTests()
+        {
+            var sa = "sa:namespace";
+            var data = "data";
+            var encrypted = "CiQAk2+d4cP3NN9n6vGm1HGQxKmn0diLlThlLqYCK1d4gKdOFi8SLxItCgxEfJ8C73FrnA5mkVISC+lIUP+Q7ndlxmahGhCbWawi0v/yuOexJkeRl/b+";
+            var decrypted = await mGoogleCloudKeyManagement.Decrypt(encrypted, sa);
+
+            Assert.Equal(data, decrypted);
+
+        }
     }
 }

--- a/tests/unit/KeyManagment/SymmetricKeyManagmentTests.cs
+++ b/tests/unit/KeyManagment/SymmetricKeyManagmentTests.cs
@@ -8,13 +8,25 @@ namespace unit.KeyManagment
 {
     public class SymmetricKeyManagementTests
     {
+        private const string Key = "tWG4dk8ARsETnFL3jCf1xtMVe05imlx9vimER7iky2s=";
+
         [Fact]
         public async Task Get_ReturnsCorrectValues()
         {
-            var key = Convert.ToBase64String(GetRandomData(32));
-            var kms = new SymmetricKeyManagement(key);
+            var kms = new SymmetricKeyManagement(Key);
             var expected = "hello";
             var encrypted = await kms.Encrypt(expected, "sa");
+            var decrypted = await kms.Decrypt(encrypted, "sa");
+
+            Assert.Equal(expected, decrypted);
+        }
+
+        [Fact]
+        public async Task RegressionTest()
+        {
+            var kms = new SymmetricKeyManagement(Key);
+            var expected = "hello";
+            var encrypted = "C4gChhspnTa5yVqYmSitrg==:tr0Ke6OGUaUa8KZgMJg14g==";
             var decrypted = await kms.Decrypt(encrypted, "sa");
 
             Assert.Equal(expected, decrypted);


### PR DESCRIPTION
Testing backward compatibility of Kamus KMS providers. Try to decrypt a previously encrypted value to ensure that the format is not broken when refactoring KMS provider.