### PR TITLE
replace k8s 1.12 with 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,10 +353,6 @@ workflows:
           requires:
             - build_api
             - lint-scripts
-      - test_crd_1_15:
-          requires:
-            - build_api
-            - lint-scripts
       - push-api-images:
           requires:
             - lint-scripts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,12 +70,6 @@ jobs:
       - store_artifacts:
           path: tests/blackbox/compose/reports/
           destination: zap-reports
-
-  test_crd_1_12:
-    machine: true
-    steps:
-      - test_crd_command:
-          kubernetesVersion: "v1.12.8"
   
   test_crd_1_13:
     machine: true
@@ -88,6 +82,12 @@ jobs:
     steps:
       - test_crd_command:
           kubernetesVersion: "v1.14.2"
+
+  test_crd_1_15:
+    machine: true
+    steps:
+      - test_crd_command:
+          kubernetesVersion: "v1.15.0"
 
   run_tests:
     docker:
@@ -341,15 +341,15 @@ workflows:
           requires:
             - build_api
             - lint-scripts
-      - test_crd_1_12:
-          requires:
-            - build_api
-            - lint-scripts
       - test_crd_1_13:
           requires:
             - build_api
             - lint-scripts
       - test_crd_1_14:
+          requires:
+            - build_api
+            - lint-scripts
+      - test_crd_1_15:
           requires:
             - build_api
             - lint-scripts
@@ -359,9 +359,9 @@ workflows:
             - build_api
             - run_tests
             - test_blackbox
-            - test_crd_1_12
             - test_crd_1_13
             - test_crd_1_14
+            - test_crd_1_15
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,13 +75,13 @@ jobs:
     machine: true
     steps:
       - test_crd_command:
-          kubernetesVersion: "v1.13.6"
+          kubernetesVersion: "v1.13.7"
 
   test_crd_1_14:
     machine: true
     steps:
       - test_crd_command:
-          kubernetesVersion: "v1.14.2"
+          kubernetesVersion: "v1.14.3"
 
   test_crd_1_15:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,6 +353,10 @@ workflows:
           requires:
             - build_api
             - lint-scripts
+      - test_crd_1_15:
+          requires:
+            - build_api
+            - lint-scripts
       - push-api-images:
           requires:
             - lint-scripts

--- a/tests/crd-controller/kind-config.yaml
+++ b/tests/crd-controller/kind-config.yaml
@@ -1,5 +1,5 @@
 kind: Config
-apiVersion: kind.sigs.k8s.io/v1alpha2
+apiVersion: kind.sigs.k8s.io/v1alpha3
 nodes:
   - role: control-plane
   - role: worker

--- a/tests/crd-controller/kind-config.yaml
+++ b/tests/crd-controller/kind-config.yaml
@@ -4,3 +4,14 @@ nodes:
   - role: control-plane
   - role: worker
     replicas: 3
+
+# this config file contains all config fields with comments
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+# the control plane node config
+- role: control-plane
+# the three workers
+- role: worker
+- role: worker
+- role: worker

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly KIND_VERSION=0.3.0
+readonly KIND_VERSION=0.4.0
 readonly CLUSTER_NAME=e2e-test
 readonly KUBECTL_VERSION=v1.13.0
 


### PR DESCRIPTION
Now that 1.15 is released, we will stop testing against 1.12 and start testing against 1.15.