### PR TITLE
gcp kms - treat data as string, not base64

### DIFF
--- a/src/crd-controller/crd-controller.csproj
+++ b/src/crd-controller/crd-controller.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.4.4.0</Version>
+    <Version>0.4.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/decrypt-api/decrypt-api.csproj
+++ b/src/decrypt-api/decrypt-api.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>0.4.4.0</Version>
+    <Version>0.4.5.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Models\" />

--- a/src/encrypt-api/encrypt-api.csproj
+++ b/src/encrypt-api/encrypt-api.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>0.4.4.0</Version>
+    <Version>0.4.5.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Models\" />

--- a/src/key-managment/GoogleCloudKeyManagment.cs
+++ b/src/key-managment/GoogleCloudKeyManagment.cs
@@ -47,7 +47,7 @@ namespace Kamus.KeyManagement
                     cryptoKeyName, 
                 ByteString.FromBase64(encryptedData));
 
-            return result.Plaintext.ToBase64();
+            return result.Plaintext.ToStringUtf8();
         }
 
         public async Task<string> Encrypt(string data, string serviceAccountId, bool createKeyIfMissing = true)
@@ -82,7 +82,7 @@ namespace Kamus.KeyManagement
             }
 
             var cryptoKeyPathName = new CryptoKeyPathName(mProjectName, mKeyringLocation, mKeyringName, safeId);
-            var encryted = await mKmsService.EncryptAsync(cryptoKeyPathName, ByteString.FromBase64(data));
+            var encryted = await mKmsService.EncryptAsync(cryptoKeyPathName, ByteString.CopyFromUtf8(data));
 
             return encryted.Ciphertext.ToBase64();
         }

--- a/tests/integration/GoogleCloudKeyManagmentTests.cs
+++ b/tests/integration/GoogleCloudKeyManagmentTests.cs
@@ -9,11 +9,7 @@ namespace integration
 {
     public class GoogleCloudKeyManagmentTests
     {
-        private readonly string mKeyRingName;
-        private readonly string mProtectionLevel;
         private readonly GoogleCloudKeyManagment mGoogleCloudKeyManagement;
-        private readonly string mProjectName;
-        private readonly string mLocation;
         private readonly IConfiguration mConfiguration;
 
         public GoogleCloudKeyManagmentTests()
@@ -44,12 +40,11 @@ namespace integration
         public async Task TestFullFlow()
         {
             var sa = "sa:namespace";
-            var data = "data";
+            var data = "The quick brown fox jumps over the lazy dog";
             var encrypted = await mGoogleCloudKeyManagement.Encrypt(data, sa);
             var decrypted = await mGoogleCloudKeyManagement.Decrypt(encrypted, sa);
 
             Assert.Equal(data, decrypted);
-
         }
 
         [Fact]
@@ -57,7 +52,7 @@ namespace integration
         {
             var sa = "sa:namespace";
             var data = "data";
-            var encrypted = "CiQAk2+d4cP3NN9n6vGm1HGQxKmn0diLlThlLqYCK1d4gKdOFi8SLxItCgxEfJ8C73FrnA5mkVISC+lIUP+Q7ndlxmahGhCbWawi0v/yuOexJkeRl/b+";
+            var encrypted = "CiQAk2+d4VDCX+mbfEUBV+2yvzWbWFuWe3qVI+0IQQ6tgH+xnmESMBIuCgyzGbLErJFqtftMuhUSDAq8ngWQqfd/eTFetBoQAZty6/68gUNAU++kCbx20Q==";
             var decrypted = await mGoogleCloudKeyManagement.Decrypt(encrypted, sa);
 
             Assert.Equal(data, decrypted);


### PR DESCRIPTION
Fix #258
GCP KMS was treating all input data as base64. Please note: this is a breaking change - data encrypted with previous versions will not be able to decrypt with this version. I think it's fine because the previous version didn't actually work :) 

Thanks @darthf1 for reporting it!