### PR TITLE
fix gkms install command

### DIFF
--- a/site/content/docs/user/install.md
+++ b/site/content/docs/user/install.md
@@ -115,7 +115,7 @@ keyManagement:
 ```
 And use the following command to deploy kamus:
 ```
- helm upgrade --install kamus soluto/kamus -f values.yaml --set-string keyManagement.googleKms.credentials="$(cat credentials.json | base64)"
+ helm upgrade --install kamus soluto/kamus -f values.yaml --set-string keyManagement.googleKms.credentials="$(cat credentials.json | base64 -w 0)"
 ```
 
 Automatic credentials rotation is supported by Google Cloud KMS (see the docs [here][gcp kms key rotation]). To enable it, just set `keyManagement.googleKms.rotationPeriod` to the desired period. The value is using [C# Time Span Format][timespan], which is simply the number of days you want. According to the docs, rotating the keys does not affect existing encrypted values - while the old version exist, decryption should work as expected.

--- a/site/content/docs/user/install.md
+++ b/site/content/docs/user/install.md
@@ -115,7 +115,7 @@ keyManagement:
 ```
 And use the following command to deploy kamus:
 ```
- helm upgrade --install kamus soluto/kamus -f values.yaml --set-string keyManagement.googleKms.credentials="$(cat credentials.json | base64 -w 0)"
+ helm upgrade --install kamus soluto/kamus -f values.yaml --set-string keyManagement.googleKms.credentials="$(base64 credentials.json | tr -d \\n)"
 ```
 
 Automatic credentials rotation is supported by Google Cloud KMS (see the docs [here][gcp kms key rotation]). To enable it, just set `keyManagement.googleKms.rotationPeriod` to the desired period. The value is using [C# Time Span Format][timespan], which is simply the number of days you want. According to the docs, rotating the keys does not affect existing encrypted values - while the old version exist, decryption should work as expected.


### PR DESCRIPTION
```
helm upgrade --install kamus soluto/kamus -f values-kamus.yaml --set-string keyManagement.googleKms.credentials="$(cat credentials.json | base64)"
```
Leads to:
```
UPGRADE FAILED
Error: YAML parse error on kamus/templates/secret.yaml: error converting YAML to JSON: yaml: line 11: could not find expected ':'
Error: UPGRADE FAILED: YAML parse error on kamus/templates/secret.yaml: error converting YAML to JSON: yaml: line 11: could not find expected ':'
```
```