### PR TITLE
Fix `serve` script for starting hugo in watch mode

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -8,6 +8,6 @@
   },
   "scripts": {
     "build": "hugo",
-    "serve": "hugo server -ws"
+    "serve": "hugo server -w"
   }
 }


### PR DESCRIPTION
When running the `serve` script this error is displayed:

>```
>Error: flag needs an argument: 's' in -s
>-s, --source string        filesystem path to read files relative from
>```

In this case specifying the path using `-s` is not necessary at all.