### PR TITLE
 added owner reference to KamusSecret

### DIFF
--- a/src/crd-controller/HostedServices/V1Alpha2Controller.cs
+++ b/src/crd-controller/HostedServices/V1Alpha2Controller.cs
@@ -85,7 +85,7 @@ namespace CustomResourceDescriptorController.HostedServices
                         return;
 
                     case WatchEventType.Deleted:
-                        //await HandleDelete(kamusSecret);
+                        //Ignore delete event - it's handled by k8s GC;
                         return;
 
                     case WatchEventType.Modified:
@@ -187,13 +187,6 @@ namespace CustomResourceDescriptorController.HostedServices
             mAuditLogger.Information("Updated a secret from KamusSecret {name} in namespace {namespace} successfully.",
                 kamusSecret.Metadata.Name,
                 secret.Metadata.NamespaceProperty);
-        }
-
-        private async Task HandleDelete(KamusSecret kamusSecret)
-        {
-            var @namespace = kamusSecret.Metadata.NamespaceProperty ?? "default";
-
-            await mKubernetes.DeleteNamespacedSecretAsync(kamusSecret.Metadata.Name, @namespace);
         }
     }
 }

--- a/src/crd-controller/Startup.cs
+++ b/src/crd-controller/Startup.cs
@@ -54,8 +54,14 @@ namespace CustomResourceDescriptorController
                 return k;
             }
             );
-                
-            services.AddHostedService<V1Alpha2Controller>();
+
+            services.AddHostedService(serviceProvider =>
+            {
+                var setOwnerReference = Configuration.GetValue<bool>("Controller:SetOwnerReference", true);
+                var kubernetes = serviceProvider.GetService<IKubernetes>();
+                var kms = serviceProvider.GetService<IKeyManagement>();
+                return new V1Alpha2Controller(kubernetes, kms, setOwnerReference);
+            });
 
             services.AddHealthChecks()
                 .AddCheck<KubernetesPermissionsHelthCheck>("permisssions check");

--- a/src/crd-controller/crd-controller.csproj
+++ b/src/crd-controller/crd-controller.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.6.4.0</Version>
+    <Version>0.6.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/decrypt-api/decrypt-api.csproj
+++ b/src/decrypt-api/decrypt-api.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>0.6.4.0</Version>
+    <Version>0.6.5.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Models\" />

--- a/src/encrypt-api/encrypt-api.csproj
+++ b/src/encrypt-api/encrypt-api.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>0.6.4.0</Version>
+    <Version>0.6.5.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Models\" />

--- a/tests/crd-controller/FlowTest.cs
+++ b/tests/crd-controller/FlowTest.cs
@@ -132,7 +132,6 @@ namespace crd_controller
 
             await DeployController();
             
-            RunKubectlCommand("apply -f tls-Secret.yaml");
             RunKubectlCommand($"apply -f {fileName}");
 
             var kubernetes = new Kubernetes(KubernetesClientConfiguration.BuildDefaultConfig());


### PR DESCRIPTION
Add the `ownerReference` metadata field so we can use Kubernetes GC to clean up secrets created by the controller and remove the delete permission from the chart.