### PR TITLE
Adding encryptor response body to error message in cli

### DIFF
--- a/cli/lib/actions/encrypt.js
+++ b/cli/lib/actions/encrypt.js
@@ -82,7 +82,7 @@ const encrypt = async ({ secret, secretFile, serviceAccount, namespace, kamusUrl
     logger.debug(`starting request to encrypt api at ${kamusUrl}`);
     const response = await performEncryptRequestAsync(data, serviceAccount, namespace, kamusUrl, certFingerprint, token);
     if (response && response.statusCode >= 300) {
-        throw new Error(`Encrypt request failed due to unexpected error. Status code: ${response.statusCode}`);
+        throw new Error(`Encrypt request failed due to unexpected error (${response.body}). Status code: ${response.statusCode}`);
     }
     logger.debug('Request to encrypt api finished successfully');
     return response.body;

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soluto-asurion/kamus-cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "CLI Tool to encrypt secrets for kamus",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Outputting the error message from the encryptor API for the cli should help troubleshooting issues when deploying Kamus for the first time. 