### PR TITLE
Allow empty string for encrypted data

### DIFF
--- a/src/key-managment/AwsKeyManagement.cs
+++ b/src/key-managment/AwsKeyManagement.cs
@@ -42,9 +42,9 @@ namespace Kamus.KeyManagement
         {
             if (string.IsNullOrEmpty(encryptedData))
             {
-                return encryptedData;
+                return "";
             }
-            
+
             var tuple = EnvelopeEncryptionUtils.Unwrap(encryptedData).ValueOrFailure("Invalid encrypted data format");
 
             var (encryptedDataKey, iv, actualEncryptedData) = tuple;

--- a/src/key-managment/AwsKeyManagement.cs
+++ b/src/key-managment/AwsKeyManagement.cs
@@ -17,7 +17,7 @@ namespace Kamus.KeyManagement
         private readonly bool mEnableAutomaticKeyRotation;
 
         public AwsKeyManagement(
-            IAmazonKeyManagementService amazonKeyManagementService,
+            IAmazonKeyManagementService amazonKeyManagementService, 
             string cmkPrefix,
             bool enableAutomaticKeyRotation)
         {
@@ -28,7 +28,7 @@ namespace Kamus.KeyManagement
 
         public async Task<string> Encrypt(string data, string serviceAccountId, bool createKeyIfMissing = true)
         {
-            var cmkPrefix = string.IsNullOrEmpty(mCmkPrefix) ? "" : $"{mCmkPrefix}-";
+            var cmkPrefix = string.IsNullOrEmpty(mCmkPrefix) ? "" : $"{mCmkPrefix}-"; 
             var masterKeyAlias = $"alias/{cmkPrefix}kamus/{KeyIdCreator.Create(serviceAccountId)}";
             var (dataKey, encryptedDataKey) = await GenerateEncryptionKey(masterKeyAlias);
 
@@ -44,6 +44,7 @@ namespace Kamus.KeyManagement
             {
                 return encryptedData;
             }
+            
             var tuple = EnvelopeEncryptionUtils.Unwrap(encryptedData).ValueOrFailure("Invalid encrypted data format");
 
             var (encryptedDataKey, iv, actualEncryptedData) = tuple;
@@ -63,13 +64,13 @@ namespace Kamus.KeyManagement
             GenerateDataKeyResponse generateKeyResponse = null;
             try
             {
-                generateKeyResponse = await mAmazonKeyManagementService.GenerateDataKeyAsync(new GenerateDataKeyRequest { KeyId = keyAlias, KeySpec = "AES_256" });
+                generateKeyResponse = await mAmazonKeyManagementService.GenerateDataKeyAsync(new GenerateDataKeyRequest { KeyId = keyAlias, KeySpec = "AES_256"});
 
             }
             catch (NotFoundException)
             {
                 await GenerateMasterKey(keyAlias);
-                generateKeyResponse = await mAmazonKeyManagementService.GenerateDataKeyAsync(new GenerateDataKeyRequest { KeyId = keyAlias, KeySpec = "AES_256" });
+                generateKeyResponse = await mAmazonKeyManagementService.GenerateDataKeyAsync(new GenerateDataKeyRequest { KeyId = keyAlias, KeySpec = "AES_256"});
             }
 
             if (generateKeyResponse.HttpStatusCode != HttpStatusCode.OK)
@@ -88,8 +89,7 @@ namespace Kamus.KeyManagement
         private async Task GenerateMasterKey(string keyAlias)
         {
             var createKeyResponse = await mAmazonKeyManagementService.CreateKeyAsync(new CreateKeyRequest { });
-            if (mEnableAutomaticKeyRotation)
-            {
+            if (mEnableAutomaticKeyRotation) {
                 await mAmazonKeyManagementService.EnableKeyRotationAsync(
                     new EnableKeyRotationRequest
                     {

--- a/src/key-managment/AwsKeyManagement.cs
+++ b/src/key-managment/AwsKeyManagement.cs
@@ -17,7 +17,7 @@ namespace Kamus.KeyManagement
         private readonly bool mEnableAutomaticKeyRotation;
 
         public AwsKeyManagement(
-            IAmazonKeyManagementService amazonKeyManagementService, 
+            IAmazonKeyManagementService amazonKeyManagementService,
             string cmkPrefix,
             bool enableAutomaticKeyRotation)
         {
@@ -28,7 +28,7 @@ namespace Kamus.KeyManagement
 
         public async Task<string> Encrypt(string data, string serviceAccountId, bool createKeyIfMissing = true)
         {
-            var cmkPrefix = string.IsNullOrEmpty(mCmkPrefix) ? "" : $"{mCmkPrefix}-"; 
+            var cmkPrefix = string.IsNullOrEmpty(mCmkPrefix) ? "" : $"{mCmkPrefix}-";
             var masterKeyAlias = $"alias/{cmkPrefix}kamus/{KeyIdCreator.Create(serviceAccountId)}";
             var (dataKey, encryptedDataKey) = await GenerateEncryptionKey(masterKeyAlias);
 
@@ -40,6 +40,10 @@ namespace Kamus.KeyManagement
 
         public async Task<string> Decrypt(string encryptedData, string serviceAccountId)
         {
+            if (string.IsNullOrEmpty(encryptedData))
+            {
+                return encryptedData;
+            }
             var tuple = EnvelopeEncryptionUtils.Unwrap(encryptedData).ValueOrFailure("Invalid encrypted data format");
 
             var (encryptedDataKey, iv, actualEncryptedData) = tuple;
@@ -59,13 +63,13 @@ namespace Kamus.KeyManagement
             GenerateDataKeyResponse generateKeyResponse = null;
             try
             {
-                generateKeyResponse = await mAmazonKeyManagementService.GenerateDataKeyAsync(new GenerateDataKeyRequest { KeyId = keyAlias, KeySpec = "AES_256"});
+                generateKeyResponse = await mAmazonKeyManagementService.GenerateDataKeyAsync(new GenerateDataKeyRequest { KeyId = keyAlias, KeySpec = "AES_256" });
 
             }
             catch (NotFoundException)
             {
                 await GenerateMasterKey(keyAlias);
-                generateKeyResponse = await mAmazonKeyManagementService.GenerateDataKeyAsync(new GenerateDataKeyRequest { KeyId = keyAlias, KeySpec = "AES_256"});
+                generateKeyResponse = await mAmazonKeyManagementService.GenerateDataKeyAsync(new GenerateDataKeyRequest { KeyId = keyAlias, KeySpec = "AES_256" });
             }
 
             if (generateKeyResponse.HttpStatusCode != HttpStatusCode.OK)
@@ -84,7 +88,8 @@ namespace Kamus.KeyManagement
         private async Task GenerateMasterKey(string keyAlias)
         {
             var createKeyResponse = await mAmazonKeyManagementService.CreateKeyAsync(new CreateKeyRequest { });
-            if (mEnableAutomaticKeyRotation) {
+            if (mEnableAutomaticKeyRotation)
+            {
                 await mAmazonKeyManagementService.EnableKeyRotationAsync(
                     new EnableKeyRotationRequest
                     {

--- a/src/key-managment/AzureKeyVaultKeyManagement.cs
+++ b/src/key-managment/AzureKeyVaultKeyManagement.cs
@@ -36,9 +36,9 @@ namespace Kamus.KeyManagement
         {
             if (string.IsNullOrEmpty(encryptedData))
             {
-                return encryptedData;
+                return "";
             }
-            
+
             var hash = KeyIdCreator.Create(serviceAccountId);
 
             var keyId = $"https://{mKeyVaultName}.vault.azure.net/keys/{hash}";

--- a/src/key-managment/AzureKeyVaultKeyManagement.cs
+++ b/src/key-managment/AzureKeyVaultKeyManagement.cs
@@ -9,7 +9,7 @@ using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Extensions.Configuration;
 using Serilog;
 
-namespace Kamus.KeyManagement 
+namespace Kamus.KeyManagement
 {
     public class AzureKeyVaultKeyManagement : IKeyManagement
     {
@@ -27,13 +27,18 @@ namespace Kamus.KeyManagement
             mKeyVaultName = configuration["KeyManagement:KeyVault:Name"];
             mKeyType = configuration["KeyManagement:KeyVault:KeyType"];
 
-            if (!short.TryParse(configuration["KeyManagement:KeyVault:KeyLength"], out mKeyLength)){
+            if (!short.TryParse(configuration["KeyManagement:KeyVault:KeyLength"], out mKeyLength))
+            {
                 throw new Exception($"Expected key length int, got {configuration["KeyManagement:KeyVault:KeyLength"]}");
             }
         }
 
         public async Task<string> Decrypt(string encryptedData, string serviceAccountId)
         {
+            if (string.IsNullOrEmpty(encryptedData))
+            {
+                return encryptedData;
+            }
             var hash = KeyIdCreator.Create(serviceAccountId);
 
             var keyId = $"https://{mKeyVaultName}.vault.azure.net/keys/{hash}";
@@ -69,7 +74,7 @@ namespace Kamus.KeyManagement
                 mLogger.Information(
                     "KeyVault key was not found for service account id {serviceAccount}, creating new one.",
                     serviceAccountId);
-                
+
                 await mKeyVaultClient.CreateKeyAsync($"https://{mKeyVaultName}.vault.azure.net", hash, mKeyType, mKeyLength);
             }
 

--- a/src/key-managment/AzureKeyVaultKeyManagement.cs
+++ b/src/key-managment/AzureKeyVaultKeyManagement.cs
@@ -9,7 +9,7 @@ using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Extensions.Configuration;
 using Serilog;
 
-namespace Kamus.KeyManagement
+namespace Kamus.KeyManagement 
 {
     public class AzureKeyVaultKeyManagement : IKeyManagement
     {
@@ -27,8 +27,7 @@ namespace Kamus.KeyManagement
             mKeyVaultName = configuration["KeyManagement:KeyVault:Name"];
             mKeyType = configuration["KeyManagement:KeyVault:KeyType"];
 
-            if (!short.TryParse(configuration["KeyManagement:KeyVault:KeyLength"], out mKeyLength))
-            {
+            if (!short.TryParse(configuration["KeyManagement:KeyVault:KeyLength"], out mKeyLength)){
                 throw new Exception($"Expected key length int, got {configuration["KeyManagement:KeyVault:KeyLength"]}");
             }
         }
@@ -39,6 +38,7 @@ namespace Kamus.KeyManagement
             {
                 return encryptedData;
             }
+            
             var hash = KeyIdCreator.Create(serviceAccountId);
 
             var keyId = $"https://{mKeyVaultName}.vault.azure.net/keys/{hash}";
@@ -74,7 +74,7 @@ namespace Kamus.KeyManagement
                 mLogger.Information(
                     "KeyVault key was not found for service account id {serviceAccount}, creating new one.",
                     serviceAccountId);
-
+                
                 await mKeyVaultClient.CreateKeyAsync($"https://{mKeyVaultName}.vault.azure.net", hash, mKeyType, mKeyLength);
             }
 

--- a/src/key-managment/GoogleCloudKeyManagement.cs
+++ b/src/key-managment/GoogleCloudKeyManagement.cs
@@ -41,9 +41,9 @@ namespace Kamus.KeyManagement
         {
             if (string.IsNullOrEmpty(encryptedData))
             {
-                return encryptedData;
+                return "";
             }
-            
+
             var safeId = KeyIdCreator.Create(serviceAccountId);
             var cryptoKeyName =
                 new CryptoKeyName(mProjectName, mKeyringLocation, mKeyringName, safeId);

--- a/src/key-managment/GoogleCloudKeyManagement.cs
+++ b/src/key-managment/GoogleCloudKeyManagement.cs
@@ -31,8 +31,8 @@ namespace Kamus.KeyManagement
             mKeyringName = keyringName;
             mKeyringLocation = keyringLocation;
             mProtectionLevel = protectionLevel;
-            mRotationPeriod = string.IsNullOrEmpty(rotationPeriod) ?
-                (TimeSpan?)null :
+            mRotationPeriod = string.IsNullOrEmpty(rotationPeriod) ? 
+                (TimeSpan?)null : 
                 TimeSpan.Parse(rotationPeriod);
         }
 
@@ -43,12 +43,13 @@ namespace Kamus.KeyManagement
             {
                 return encryptedData;
             }
+            
             var safeId = KeyIdCreator.Create(serviceAccountId);
             var cryptoKeyName =
                 new CryptoKeyName(mProjectName, mKeyringLocation, mKeyringName, safeId);
-            var result =
+            var result = 
                 await mKmsService.DecryptAsync(
-                    cryptoKeyName,
+                    cryptoKeyName, 
                 ByteString.FromBase64(encryptedData));
 
             return result.Plaintext.ToStringUtf8();
@@ -64,8 +65,7 @@ namespace Kamus.KeyManagement
             try
             {
                 await mKmsService.GetCryptoKeyAsync(cryptoKeyName);
-            }
-            catch (RpcException e) when (e.StatusCode == StatusCode.NotFound && createKeyIfMissing)
+            } catch (RpcException e) when (e.StatusCode == StatusCode.NotFound && createKeyIfMissing) 
             {
                 var key = new CryptoKey
                 {
@@ -83,7 +83,7 @@ namespace Kamus.KeyManagement
                 }
 
                 var request = await mKmsService.CreateCryptoKeyAsync(keyring, safeId, key);
-
+               
             }
 
             var cryptoKeyPathName = new CryptoKeyPathName(mProjectName, mKeyringLocation, mKeyringName, safeId);

--- a/src/key-managment/GoogleCloudKeyManagement.cs
+++ b/src/key-managment/GoogleCloudKeyManagement.cs
@@ -31,20 +31,24 @@ namespace Kamus.KeyManagement
             mKeyringName = keyringName;
             mKeyringLocation = keyringLocation;
             mProtectionLevel = protectionLevel;
-            mRotationPeriod = string.IsNullOrEmpty(rotationPeriod) ? 
-                (TimeSpan?)null : 
+            mRotationPeriod = string.IsNullOrEmpty(rotationPeriod) ?
+                (TimeSpan?)null :
                 TimeSpan.Parse(rotationPeriod);
         }
 
 
         public async Task<string> Decrypt(string encryptedData, string serviceAccountId)
         {
+            if (string.IsNullOrEmpty(encryptedData))
+            {
+                return encryptedData;
+            }
             var safeId = KeyIdCreator.Create(serviceAccountId);
             var cryptoKeyName =
                 new CryptoKeyName(mProjectName, mKeyringLocation, mKeyringName, safeId);
-            var result = 
+            var result =
                 await mKmsService.DecryptAsync(
-                    cryptoKeyName, 
+                    cryptoKeyName,
                 ByteString.FromBase64(encryptedData));
 
             return result.Plaintext.ToStringUtf8();
@@ -60,7 +64,8 @@ namespace Kamus.KeyManagement
             try
             {
                 await mKmsService.GetCryptoKeyAsync(cryptoKeyName);
-            } catch (RpcException e) when (e.StatusCode == StatusCode.NotFound && createKeyIfMissing) 
+            }
+            catch (RpcException e) when (e.StatusCode == StatusCode.NotFound && createKeyIfMissing)
             {
                 var key = new CryptoKey
                 {
@@ -78,7 +83,7 @@ namespace Kamus.KeyManagement
                 }
 
                 var request = await mKmsService.CreateCryptoKeyAsync(keyring, safeId, key);
-               
+
             }
 
             var cryptoKeyPathName = new CryptoKeyPathName(mProjectName, mKeyringLocation, mKeyringName, safeId);

--- a/tests/integration/AwsKeyManagementTests.cs
+++ b/tests/integration/AwsKeyManagementTests.cs
@@ -26,7 +26,7 @@ namespace integration
 
             var kmsService = new AmazonKeyManagementServiceClient(awsKey, awsSecret, RegionEndpoint.USEast1);
 
-            mAwsKeyManagement = new AwsKeyManagement(kmsService, "", true);
+            mAwsKeyManagement = new AwsKeyManagement(kmsService,"", true);
         }
 
         [Fact]
@@ -59,7 +59,6 @@ namespace integration
             var decrypted = await mAwsKeyManagement.Decrypt(encrypted, sa);
 
             Assert.Equal(encrypted, decrypted);
-
         }
     }
 

--- a/tests/integration/AwsKeyManagementTests.cs
+++ b/tests/integration/AwsKeyManagementTests.cs
@@ -26,7 +26,7 @@ namespace integration
 
             var kmsService = new AmazonKeyManagementServiceClient(awsKey, awsSecret, RegionEndpoint.USEast1);
 
-            mAwsKeyManagement = new AwsKeyManagement(kmsService,"", true);
+            mAwsKeyManagement = new AwsKeyManagement(kmsService, "", true);
         }
 
         [Fact]
@@ -49,6 +49,17 @@ namespace integration
             var decrypted = await mAwsKeyManagement.Decrypt(encrypted, sa);
 
             Assert.Equal(data, decrypted);
+        }
+
+        [Fact]
+        public async Task TestEmptyString()
+        {
+            var sa = "sa:namespace";
+            var encrypted = "";
+            var decrypted = await mAwsKeyManagement.Decrypt(encrypted, sa);
+
+            Assert.Equal(encrypted, decrypted);
+
         }
     }
 

--- a/tests/integration/AzureKeyVaultIntegrationTests.cs
+++ b/tests/integration/AzureKeyVaultIntegrationTests.cs
@@ -31,19 +31,19 @@ namespace integration
         {
             var clientId = mConfiguration.GetValue<string>("ActiveDirectory:ClientId");
             var clientSecret = mConfiguration.GetValue<string>("ActiveDirectory:ClientSecret");
-            mKeyVaultClient = new KeyVaultClient((authority, resource, scope) =>
+            mKeyVaultClient = new KeyVaultClient((authority, resource, scope) => 
                 Utils.AuthenticationCallback(clientId, clientSecret, authority, resource, scope));
             mAzureKeyManagement = new AzureKeyVaultKeyManagement(mKeyVaultClient, mConfiguration);
         }
-
+        
         [Fact]
         public async Task Encrypt_KeyDoesNotExist_CreateIt()
         {
             var data = "test";
             var serviceAccountId = "default:" + Guid.NewGuid();
-
+            
             await mAzureKeyManagement.Encrypt(data, serviceAccountId);
-
+            
             var keyId = $"https://{mKeyVaultName}.vault.azure.net/keys/{ComputeKeyId(serviceAccountId)}";
 
             try
@@ -68,7 +68,7 @@ namespace integration
             var serviceAccountId = "default:default:";
 
             var encryptedData = await mAzureKeyManagement.Encrypt(data, serviceAccountId);
-
+            
             var decryptedData = await mAzureKeyManagement.Decrypt(encryptedData, serviceAccountId);
 
             Assert.Equal(data, decryptedData);
@@ -89,7 +89,7 @@ namespace integration
 
         private string ComputeKeyId(string serviceUserName)
         {
-            return
+            return 
                 WebEncoders.Base64UrlEncode(
                         SHA256.Create().ComputeHash(
                             Encoding.UTF8.GetBytes(serviceUserName)))

--- a/tests/integration/AzureKeyVaultIntegrationTests.cs
+++ b/tests/integration/AzureKeyVaultIntegrationTests.cs
@@ -31,19 +31,19 @@ namespace integration
         {
             var clientId = mConfiguration.GetValue<string>("ActiveDirectory:ClientId");
             var clientSecret = mConfiguration.GetValue<string>("ActiveDirectory:ClientSecret");
-            mKeyVaultClient = new KeyVaultClient((authority, resource, scope) => 
+            mKeyVaultClient = new KeyVaultClient((authority, resource, scope) =>
                 Utils.AuthenticationCallback(clientId, clientSecret, authority, resource, scope));
             mAzureKeyManagement = new AzureKeyVaultKeyManagement(mKeyVaultClient, mConfiguration);
         }
-        
+
         [Fact]
         public async Task Encrypt_KeyDoesNotExist_CreateIt()
         {
             var data = "test";
             var serviceAccountId = "default:" + Guid.NewGuid();
-            
+
             await mAzureKeyManagement.Encrypt(data, serviceAccountId);
-            
+
             var keyId = $"https://{mKeyVaultName}.vault.azure.net/keys/{ComputeKeyId(serviceAccountId)}";
 
             try
@@ -68,7 +68,7 @@ namespace integration
             var serviceAccountId = "default:default:";
 
             var encryptedData = await mAzureKeyManagement.Encrypt(data, serviceAccountId);
-            
+
             var decryptedData = await mAzureKeyManagement.Decrypt(encryptedData, serviceAccountId);
 
             Assert.Equal(data, decryptedData);
@@ -89,11 +89,21 @@ namespace integration
 
         private string ComputeKeyId(string serviceUserName)
         {
-            return 
+            return
                 WebEncoders.Base64UrlEncode(
                         SHA256.Create().ComputeHash(
                             Encoding.UTF8.GetBytes(serviceUserName)))
                     .Replace("_", "-");
+        }
+
+        [Fact]
+        public async Task TestEmptyString()
+        {
+            var serviceAccountId = "default:default:";
+            var encrypted = "";
+            var decrypted = await mAzureKeyManagement.Decrypt(encrypted, serviceAccountId);
+
+            Assert.Equal(encrypted, decrypted);
         }
     }
 }

--- a/tests/integration/GoogleCloudKeyManagementTests.cs
+++ b/tests/integration/GoogleCloudKeyManagementTests.cs
@@ -67,7 +67,6 @@ namespace integration
             var decrypted = await mGoogleCloudKeyManagement.Decrypt(encrypted, sa);
 
             Assert.Equal(encrypted, decrypted);
-
         }
     }
 }

--- a/tests/integration/GoogleCloudKeyManagementTests.cs
+++ b/tests/integration/GoogleCloudKeyManagementTests.cs
@@ -58,5 +58,16 @@ namespace integration
             Assert.Equal(data, decrypted);
 
         }
+
+        [Fact]
+        public async Task TestEmptyString()
+        {
+            var sa = "sa:namespace";
+            var encrypted = "";
+            var decrypted = await mGoogleCloudKeyManagement.Decrypt(encrypted, sa);
+
+            Assert.Equal(encrypted, decrypted);
+
+        }
     }
 }


### PR DESCRIPTION
Decrypting empty string will simply return an empty string without failing. This is to support one of our use case where I have an app that I want to instantiate many times and some variant of this app don't require all secrets. Since I want to reuse the same template for the config map, I would simply put an empty string for the secrets that are not required instead of having to encrypt a dummy value for the decryptor to not fail.