### PR TITLE
Add MACOS support for the controller tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ node_modules/
 **/vendor/
 init-container/token.txt
 init-container/decrypted/**
+
+kubectl
+kind

--- a/tests/crd-controller/kind-config.yaml
+++ b/tests/crd-controller/kind-config.yaml
@@ -3,5 +3,3 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker
-- role: worker
-- role: worker

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -33,7 +33,7 @@ cleanup() {
     echo 'Removing kind e2e-test cluster'
     kind delete clusters e2e-test
     echo 'Restoring kubeconfig'
-    mv "$HOME/.kube/config.bkp" "$HOME/.kube/config"
+    mv "$HOME/.kube/config.bkp" "$HOME/.kube/config"  || echo "No original kubeconfig to backup was found."
     echo 'Done!'
 }
 

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -6,7 +6,6 @@ set -o pipefail
 
 readonly KIND_VERSION=0.8.1
 readonly CLUSTER_NAME=e2e-test
-readonly KUBECTL_VERSION=v1.13.0
 
 if [ "$(uname)" == "Darwin" ]; then
     machine=darwin
@@ -15,7 +14,7 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
 fi
 
 backup_current_kubeconfig() {
-    mv $HOME/.kube/config $HOME/.kube/config.bkp
+    mv "$HOME/.kube/config" "$HOME/.kube/config.bkp"
 }
 
 run_e2e_container() {
@@ -31,10 +30,10 @@ run_e2e_container() {
 cleanup() {
     echo 'Removing e2e container...'
     docker kill e2e > /dev/null 2>&1
-    # echo 'Removing kind e2e-test cluster'
-    # kind delete clusters e2e-test
+    echo 'Removing kind e2e-test cluster'
+    kind delete clusters e2e-test
     echo 'Restoring kubeconfig'
-    mv $HOME/.kube/config.bkp $HOME/.kube/config
+    mv "$HOME/.kube/config.bkp" "$HOME/.kube/config"
     echo 'Done!'
 }
 
@@ -67,12 +66,10 @@ create_kind_cluster() {
     kubeconfig_path="$HOME/.kube/config"
     if [ "$machine" == "darwin" ]; then
         kubectl config set-cluster kind-e2e-test --insecure-skip-tls-verify=true
-        cp $HOME/.kube/config $HOME/.kube/config.edited
-        kubeconfig_path="$HOME/.kube/config.edited"
-        sed -i "" 's/127.0.0.1/host.docker.internal/g' $kubeconfig_path
+        sed -i "" 's/127.0.0.1/host.docker.internal/g' "$kubeconfig_path"
     fi
-    docker cp $kubeconfig_path e2e:/root/.kube/config
 
+    docker cp "$kubeconfig_path" e2e:/root/.kube/config
     echo -n 'Waiting for cluster to be ready...'
     until ! grep --quiet 'NotReady' <(docker_exec kubectl get nodes --no-headers); do
         printf '.'

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -9,7 +9,7 @@ readonly CLUSTER_NAME=e2e-test
 
 if [ "$(uname)" == "Darwin" ]; then
     machine=darwin
-elif [ "$(uname)" == "*Linux*" ]; then
+else
     machine=linux
 fi
 

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -14,7 +14,7 @@ else
 fi
 
 backup_current_kubeconfig() {
-    mv "$HOME/.kube/config" "$HOME/.kube/config.bkp" 2>/dev/null
+    mv "$HOME/.kube/config" "$HOME/.kube/config.bkp" || echo "No original kubeconfig to backup was found."
 }
 
 run_e2e_container() {

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -9,7 +9,7 @@ readonly CLUSTER_NAME=e2e-test
 
 if [ "$(uname)" == "Darwin" ]; then
     machine=darwin
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+elif [ "$(( substr $(uname -s) 1 5))" == "Linux" ]; then
     machine=linux
 fi
 

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -3,13 +3,13 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-set -x
+
 readonly KIND_VERSION=0.8.1
 readonly CLUSTER_NAME=e2e-test
 
 if [ "$(uname)" == "Darwin" ]; then
     machine=darwin
-elif [ "$(($(uname -s):1:5))" == "Linux" ]; then
+else if [ "$(uname)" == "*Linux*" ]; then
     machine=linux
 fi
 

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -9,7 +9,7 @@ readonly CLUSTER_NAME=e2e-test
 
 if [ "$(uname)" == "Darwin" ]; then
     machine=darwin
-else if [ "$(uname)" == "*Linux*" ]; then
+elif [ "$(uname)" == "*Linux*" ]; then
     machine=linux
 fi
 

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-
+set -x
 readonly KIND_VERSION=0.8.1
 readonly CLUSTER_NAME=e2e-test
 

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-set -x
+
 readonly KIND_VERSION=0.8.1
 readonly CLUSTER_NAME=e2e-test
 readonly KUBECTL_VERSION=v1.13.0

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-set -x
+
 readonly KIND_VERSION=0.8.1
 readonly CLUSTER_NAME=e2e-test
 

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -14,7 +14,7 @@ elif [ "$(uname)" == "*Linux*" ]; then
 fi
 
 backup_current_kubeconfig() {
-    mv "$HOME/.kube/config" "$HOME/.kube/config.bkp"
+    mv "$HOME/.kube/config" "$HOME/.kube/config.bkp" 2>/dev/null
 }
 
 run_e2e_container() {

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -50,7 +50,7 @@ create_kind_cluster() {
     chmod +x kind
     sudo mv kind /usr/local/bin/kind
 
-    curl -sfSLO https://storage.googleapis.com/kubernetes-release/release/$K8S_VERSION/bin/linux/amd64/kubectl
+    curl -sfSLO https://storage.googleapis.com/kubernetes-release/release/"$K8S_VERSION"/bin/linux/amd64/kubectl
     chmod +x kubectl
 
     docker cp kubectl e2e:/usr/local/bin/kubectl

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -3,13 +3,13 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-
+set -x
 readonly KIND_VERSION=0.8.1
 readonly CLUSTER_NAME=e2e-test
 
 if [ "$(uname)" == "Darwin" ]; then
     machine=darwin
-elif [ "$(( substr $(uname -s) 1 5))" == "Linux" ]; then
+elif [ "$(($(uname -s):1:5))" == "Linux" ]; then
     machine=linux
 fi
 


### PR DESCRIPTION
Running the controller tests on mac requires:
1. Downloading the darwin kind image
2. Changing the kubeconfig to use `docker.host.local` instead of `127.0.0.1` since there is no host network in MACOS docker.

Few more minor improvements:
* Backup and restore of original kubeconfig before and on cleanup to support local run better.
* Use kubectl with the same version of the cluster being tested
* Use one worker node instead of 3