### PR TITLE
Fix CLI CI Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,8 +128,10 @@ jobs:
       - run:
           name: lint
           command: |
-            apt-get update -y
-            apt-get install -y shellcheck
+            wget -P tmp_install_folder/ https://storage.googleapis.com/shellcheck/shellcheck-v0.7.1.linux.x86_64.tar.xz
+            tar xvf tmp_install_folder/shellcheck-latest.linux.x86_64.tar.xz -C tmp_install_folder
+            cp tmp_install_folder/shellcheck-latest/shellcheck /usr/bin/shellcheck
+            rm -r tmp_install_folder
             shellcheck -x ci/version_to_deploy.sh
             shellcheck -x ci/version_to_deploy_init.sh
             shellcheck -x ci/version_to_deploy_cli_docker.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,8 @@ jobs:
           name: lint
           command: |
             wget -P tmp_install_folder/ https://storage.googleapis.com/shellcheck/shellcheck-v0.7.1.linux.x86_64.tar.xz
-            tar xvf tmp_install_folder/shellcheck-latest.linux.x86_64.tar.xz -C tmp_install_folder
-            cp tmp_install_folder/shellcheck-latest/shellcheck /usr/bin/shellcheck
+            tar xvf tmp_install_folder/shellcheck-v0.7.1.linux.x86_64.tar.xz -C tmp_install_folder
+            cp tmp_install_folder/shellcheck-v0.7.1/shellcheck /usr/bin/shellcheck
             rm -r tmp_install_folder
             shellcheck -x ci/version_to_deploy.sh
             shellcheck -x ci/version_to_deploy_init.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,11 @@ commands:
             kubernetesVersion: parameters.kubernetesVersion
           command: |
             tests/crd-controller/run-tests.sh << parameters.kubernetesVersion >>
-          no_output_timeout: 3600
+          no_output_timeout: 1h
 jobs:
   test_cli:
     docker:
-      - image: node:10-alpine
+      - image: timbru31/node-alpine-git:14
 
     steps:
       - checkout
@@ -122,12 +122,14 @@ jobs:
 
   lint-scripts:
     docker:
-      - image: koalaman/shellcheck-alpine
+      - image: ubuntu:bionuc
     steps:
       - checkout
       - run:
           name: lint
           command: |
+            apt-get update -y
+            apt-get install -y shellcheck
             shellcheck -x ci/version_to_deploy.sh
             shellcheck -x ci/version_to_deploy_init.sh
             shellcheck -x ci/version_to_deploy_cli_docker.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
 
   lint-scripts:
     docker:
-      - image: ubuntu:bionuc
+      - image: ubuntu:bionic
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
       - run:
           name: lint
           command: |
-            wget -P tmp_install_folder/ https://storage.googleapis.com/shellcheck/shellcheck-v0.7.1.linux.x86_64.tar.xz
+            wget -P tmp_install_folder/ https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.x86_64.tar.xz
             tar xvf tmp_install_folder/shellcheck-v0.7.1.linux.x86_64.tar.xz -C tmp_install_folder
             cp tmp_install_folder/shellcheck-v0.7.1/shellcheck /usr/bin/shellcheck
             rm -r tmp_install_folder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
 
   lint-scripts:
     docker:
-      - image: ubuntu:bionic
+      - image: node:14
     steps:
       - checkout
       - run:


### PR DESCRIPTION
For some reason, Circle builds fails when git isn't existed in the base image for the steps.
This PR move to git included images.