### PR TITLE
Fix CRD Controller logging

### DIFF
--- a/site/content/docs/user/CHANGELOG.md
+++ b/site/content/docs/user/CHANGELOG.md
@@ -8,6 +8,10 @@ menu:
 ---
 # Changelog
 
+## kamus-0.9.0.2 (14/02/2021)
+
+#### bug :
+- Fix crd controller logging
 
 ## kamus-0.9.0.1 (14/02/2021)
 

--- a/src/crd-controller/Startup.cs
+++ b/src/crd-controller/Startup.cs
@@ -41,6 +41,10 @@ namespace CustomResourceDescriptorController
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices (IServiceCollection services) {
 
+            Log.Logger = new LoggerConfiguration ()
+                .ReadFrom.Configuration (Configuration)
+                .CreateLogger ();
+            
             services.AddSingleton(Configuration);
             services.AddControllers().AddNewtonsoftJson();
 
@@ -70,13 +74,8 @@ namespace CustomResourceDescriptorController
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure (IApplicationBuilder app, IWebHostEnvironment env) {
-            Log.Logger = new LoggerConfiguration ()
-                .ReadFrom.Configuration (Configuration)
-                .CreateLogger ();
-
             app.UseRouting();
-
-
+            
             app.UseLoggingMiddleware();
 
             app.UseEndpoints(endpoints =>

--- a/src/crd-controller/crd-controller.csproj
+++ b/src/crd-controller/crd-controller.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.9.0.1</Version>
+    <Version>0.9.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/decrypt-api/decrypt-api.csproj
+++ b/src/decrypt-api/decrypt-api.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>0.9.0.1</Version>
+    <Version>0.9.0.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Models\" />

--- a/src/encrypt-api/encrypt-api.csproj
+++ b/src/encrypt-api/encrypt-api.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>0.9.0.1</Version>
+    <Version>0.9.0.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Models\" />


### PR DESCRIPTION
The logger was registered after the hosted service was already initialized, preventing the hosted service from using the actual configured logger.﻿
