### PR TITLE
Fix controller memory leak

### DIFF
--- a/src/crd-controller/HostedServices/V1Alpha2Controller.cs
+++ b/src/crd-controller/HostedServices/V1Alpha2Controller.cs
@@ -76,8 +76,9 @@ namespace CustomResourceDescriptorController.HostedServices
             mSubscription = ObserveKamusSecret(token);
             Observable.Interval(TimeSpan.FromSeconds(mReconciliationIntervalInSeconds)).Subscribe((s) =>
             {
-                mSubscription.Dispose();
+                var oldSubscription = mSubscription;
                 mSubscription = ObserveKamusSecret(token);
+                oldSubscription.Dispose();
             });
             
             mLogger.Information("Starting watch for KamusSecret V1Alpha2 events");

--- a/src/crd-controller/HostedServices/V1Alpha2Controller.cs
+++ b/src/crd-controller/HostedServices/V1Alpha2Controller.cs
@@ -70,6 +70,7 @@ namespace CustomResourceDescriptorController.HostedServices
                         Environment.Exit(0);
                     });
         }
+
         public Task StartAsync(CancellationToken token)
         {
             mSubscription = ObserveKamusSecret(token);

--- a/src/crd-controller/HostedServices/V1Alpha2Controller.cs
+++ b/src/crd-controller/HostedServices/V1Alpha2Controller.cs
@@ -53,6 +53,7 @@ namespace CustomResourceDescriptorController.HostedServices
                     ApiVersion,
                     "kamussecrets",
                     token)
+                .Take(1)
                 .SelectMany(x =>
                     Observable.FromAsync(async () => await HandleEvent(x.Item1, x.Item2))
                 )

--- a/src/crd-controller/crd-controller.csproj
+++ b/src/crd-controller/crd-controller.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.9.0.7</Version>
+    <Version>0.9.0.8</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/crd-controller/utils/KubernetesExtensions.cs
+++ b/src/crd-controller/utils/KubernetesExtensions.cs
@@ -2,6 +2,7 @@
 using System.Reactive.Linq;
 using System.Threading;
 using k8s;
+using Microsoft.VisualBasic;
 
 namespace CustomResourceDescriptorController.utils
 {
@@ -13,22 +14,24 @@ namespace CustomResourceDescriptorController.utils
             string version,
             string plural,
             CancellationToken cancellationToken
-            ) where TCRD : class
+        ) where TCRD : class
         {
+            Watcher<TCRD> watcher = null;
             return Observable.FromAsync(async () =>
-            {
-                var subject = new System.Reactive.Subjects.Subject<(WatchEventType, TCRD)>();
-                var path = $"apis/{group}/{version}/watch/{plural}";
-                await kubernetes.WatchObjectAsync<TCRD>(path,
-                    timeoutSeconds: int.MaxValue,
-                    onEvent: (@type, @event) => subject.OnNext((@type, @event)),
-                    onError: e => subject.OnError(e),
-                    onClosed: () => subject.OnCompleted(), cancellationToken: cancellationToken);
-                return subject;
-            })
+                {
+                    var subject = new System.Reactive.Subjects.Subject<(WatchEventType, TCRD)>();
+                    var path = $"apis/{group}/{version}/watch/{plural}";
+                    watcher = await kubernetes.WatchObjectAsync<TCRD>(path,
+                        timeoutSeconds: int.MaxValue,
+                        onEvent: (@type, @event) => subject.OnNext((@type, @event)),
+                        onError: e => subject.OnError(e),
+                        onClosed: () => subject.OnCompleted(), cancellationToken: cancellationToken);
+                    return subject;
+                })
                 .SelectMany(x => x)
                 .Select(t => (t.Item1, t.Item2 as TCRD))
-                .Where(t => t.Item2 != null);
+                .Where(t => t.Item2 != null)
+                .Finally(() => watcher?.Dispose());
         }
     }
 }

--- a/src/crd-controller/utils/KubernetesExtensions.cs
+++ b/src/crd-controller/utils/KubernetesExtensions.cs
@@ -2,7 +2,6 @@
 using System.Reactive.Linq;
 using System.Threading;
 using k8s;
-using Microsoft.VisualBasic;
 
 namespace CustomResourceDescriptorController.utils
 {

--- a/src/decrypt-api/decrypt-api.csproj
+++ b/src/decrypt-api/decrypt-api.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>0.9.0.7</Version>
+    <Version>0.9.0.8</Version>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Models\" />

--- a/src/encrypt-api/encrypt-api.csproj
+++ b/src/encrypt-api/encrypt-api.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>0.9.0.7</Version>
+    <Version>0.9.0.8</Version>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Models\" />


### PR DESCRIPTION
Since the reconciliation loop was added, the watcher not being disposed correctly leading to a memory leak.
Closes #617 