### PR TITLE
Updating base images to fix vulnerabilities

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
-bin\
-obj\
+bin/
+obj/
 cmd/
 **/bin/*
 **/obj/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build-env
 
 ARG PROJECT_NAME=decrypt-api
 
@@ -15,16 +15,16 @@ COPY  ./src/key-managment ./key-managment
 RUN dotnet publish $PROJECT_NAME/$PROJECT_NAME.csproj -c Release -o ./obj/Docker/publish
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS release
+FROM mcr.microsoft.com/dotnet/aspnet:3.1-focal AS release
 ARG PROJECT_NAME=decrypt-api
 ENV PROJECT_NAME_ENV=$PROJECT_NAME
-RUN groupadd dotnet && \
-    useradd dotnet -g dotnet --home /home/dotnet
+RUN groupadd -g 1000 dotnet && \
+    useradd -u 1000 dotnet -g dotnet --home /home/dotnet
 
 USER dotnet
 
 WORKDIR /home/dotnet/app
 ENV ASPNETCORE_URLS=http://+:9999
-COPY --from=build-env /app/obj/Docker/publish .
+COPY --from=build-env --chown=dotnet:dotnet /app/obj/Docker/publish .
 
 ENTRYPOINT dotnet $PROJECT_NAME_ENV.dll

--- a/init-container/Dockerfile
+++ b/init-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:14.18.3-alpine3.14
 
 RUN mkdir /home/node/app
 # Create app directory

--- a/site/content/docs/user/CHANGELOG.md
+++ b/site/content/docs/user/CHANGELOG.md
@@ -6,46 +6,57 @@ menu:
     identifier: "changelog"
     weight: 6
 ---
+
 # Changelog
+
+## kamus-0.9.0.8 (18/03/2022)
+
+#### chore :
+
+- Upgrade base images to address security vulnerabilities
 
 ## kamus-0.9.0.7 (18/03/2021)
 
 #### feature :
+
 - The controller now reconcile all KamusSecrets every 60 seconds (make sure to recreate if any secret is missing)
 
 ## kamus-0.9.0.6 (15/02/2021)
 
 #### feature :
+
 - Container images moved to ghcr
 
 ## kamus-0.9.0.5 (15/02/2021)
 
 #### bug :
+
 - Prevent controller restarts every 60 minutes
 
 ## kamus-0.9.0.2 (14/02/2021)
 
 #### bug :
+
 - Fix crd controller logging
 
 ## kamus-0.9.0.1 (14/02/2021)
 
 #### chore :
+
 - Remove SSL endpoint since we don't have conversion webhook anymore
 
 ## kamus-0.9 (11/02/2021)
 
 #### Breaking :
+
 - Kubernetes 1.16 is the minimum required version since KamusSecret CRD moved to `apiextensions.k8s.io/v1`
 - v1alpha1 KamusSecret was removed. Please migrate to v1alpha2.
 
   To migrate from v1alpha1 to v1alpha2 all you need to do is:
 
-  * Change the key data to stringData
-  * Change the apiVersion to "soluto.com/v1alpha2"
+  - Change the key data to stringData
+  - Change the apiVersion to "soluto.com/v1alpha2"
 
-    
-  
 ## kamus-0.8 (31/08/2020)
 
 #### Breaking Bug Fixes:
@@ -54,13 +65,11 @@ menu:
 
   If you've encrypted secrets using kamus 0.7.0.0 and above, your AWS key aliases were created without prefix, so you have to re-encrypt them in order to use kamus 0.8.0.0 that now uses the cmkPrefix correctly.
 
-
 ## kamus-0.7 (07/06/2020)
 
 #### Bug Fixes:
 
 - [**bug**] Decryption doesn't fail when doing from unauthorized service account [#526](https://github.com/Soluto/kamus/issues/526)
-
 
 ## kamus-0.6 (19/09/2019)
 
@@ -74,8 +83,7 @@ menu:
 - [**bug**] BUG: init container -n flag required when outputting files format [#270](https://github.com/Soluto/kamus/issues/270)
 - [**bug**] GCP KMS support is broken since version 0.4.4.0 [#251](https://github.com/Soluto/kamus/issues/251)
 
-The released can be used using the latest chart version - 0.4.0
----
+## The released can be used using the latest chart version - 0.4.0
 
 ## kamus-0.5 (30/06/2019)
 
@@ -94,7 +102,7 @@ The released can be used using the latest chart version - 0.4.0
 
 #### Bug Fixes:
 
-- [**bug**] type=KamusSecret  is NOT working. [#196](https://github.com/Soluto/kamus/issues/196)
+- [**bug**] type=KamusSecret is NOT working. [#196](https://github.com/Soluto/kamus/issues/196)
 - [**bug**] CRD Controller fails to decrypt [#163](https://github.com/Soluto/kamus/issues/163)
 - [**bug**] getting error when trying to encrypt with awskms [#142](https://github.com/Soluto/kamus/issues/142)
 - [**bug**] Failed to run the example when Kamus is not running in the default namespace [#132](https://github.com/Soluto/kamus/issues/132)
@@ -137,6 +145,7 @@ Available on chart version 0.1.7
 ---
 
 ## kamus-0.1 (17/01/2019)
+
 - [**enhancement**][**good first issue**][**help wanted**] Make CLI arguments order invariant [#77](https://github.com/Soluto/kamus/issues/77)
 - [**enhancement**] Move to versioned docker images [#74](https://github.com/Soluto/kamus/issues/74)
 - [**enhancement**][**help wanted**] Add support for GCP KMS [#61](https://github.com/Soluto/kamus/issues/61)

--- a/src/crd-controller/crd-controller.csproj
+++ b/src/crd-controller/crd-controller.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.9.0.7</Version>
+    <Version>0.9.0.8</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/decrypt-api/decrypt-api.csproj
+++ b/src/decrypt-api/decrypt-api.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>0.9.0.7</Version>
+    <Version>0.9.0.8</Version>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Models\" />

--- a/src/encrypt-api/encrypt-api.csproj
+++ b/src/encrypt-api/encrypt-api.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>0.9.0.7</Version>
+    <Version>0.9.0.8</Version>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Models\" />


### PR DESCRIPTION
The current base images used to build kamus images are old and contains many vulnerabilities. 

This PR:
- Updates the init-container base image to use the latest node 14 on alpine.
- Changes the base image of the dotnet apps from debian to ubuntu. The latest debian buster image contains many critical and high vulnerabilities. The latest ubuntu focal image contains fewer vulnerabilities and only medium at most (as per snyk).
- Updates the dotnet base image to use the new repo (as per https://github.com/dotnet/dotnet-docker/issues/2375)
- Set explicits user and group ids for the dotnet user

I tried to run the dotnet apps using the latest alpine image, but got stuck on the multiple issue of the grpc core library in alpine (as per https://github.com/grpc/grpc/issues/21446). I tried multiple options as recommended in the issue, but in the end I was only able to reproduce the segfault issue https://github.com/Soluto/kamus/issues/455. The only work-around that I could get working was by downgrading lib6-compat to 1.19 (as per https://github.com/grpc/grpc/issues/21446#issuecomment-698396812) but it introduces different critical and high vulnerabilities because of older version of apk and musl. 

When the Google KMS package migrate to the latest Grpc.Net.Client package ([planned 2022 Q1 or Q2](https://github.com/googleapis/google-cloud-dotnet/issues/7574)), we should be able to ditch ubuntu and run kamus on alpine, reducing the attack surface even further.