### PR TITLE
fix ci errors in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,19 +91,19 @@ jobs:
     machine: true
     steps:
       - test_crd_command:
-          kubernetesVersion: "v1.18.15"
+          kubernetesVersion: "v1.18.20"
 
   test_crd_1_19:
     machine: true
     steps:
       - test_crd_command:
-          kubernetesVersion: "v1.19.7"
+          kubernetesVersion: "v1.19.16"
 
   test_crd_1_20:
     machine: true
     steps:
       - test_crd_command:
-          kubernetesVersion: "v1.20.2"
+          kubernetesVersion: "v1.20.15"
 
   run_tests:
     docker:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
-bin\
-obj\
+bin/
+obj/
 cmd/
 **/bin/*
 **/obj/*

--- a/init-container/tests/docker-compose.yaml
+++ b/init-container/tests/docker-compose.yaml
@@ -18,3 +18,8 @@ services:
       context: Wiremock
     ports:
       - 8080:8080
+    healthcheck:
+      test: curl -f http://localhost:8080/__admin/mappings
+      interval: 3s
+      timeout: 2s
+      retries: 5

--- a/init-container/tests/run_test.sh
+++ b/init-container/tests/run_test.sh
@@ -12,6 +12,8 @@ docker-compose up -d --build wiremock
 
 docker-compose build decryptor
 
+docker-compose logs wiremock
+
 echo "running decryptor - json format"
 
 OUTPUT_FORMAT=json docker-compose run decryptor

--- a/init-container/tests/run_test.sh
+++ b/init-container/tests/run_test.sh
@@ -12,7 +12,7 @@ docker-compose up -d --build wiremock
 
 docker-compose build decryptor
 
-docker-compose logs wiremock
+timeout 10s bash -c 'until docker-compose ps wiremock | grep \(healthy\); do sleep 1; done'
 
 echo "running decryptor - json format"
 

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -95,6 +95,14 @@ run_test() {
 
 main() {
     backup_current_kubeconfig
+
+    echo "------- GIORA TESTING -----------"
+
+    echo "docker info"
+    docker info
+
+    echo "------- GIORA TESTING -----------"
+
     run_e2e_container
     trap cleanup EXIT
 

--- a/tests/crd-controller/run-tests.sh
+++ b/tests/crd-controller/run-tests.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly KIND_VERSION=0.10.0
+readonly KIND_VERSION=0.14.0
 readonly CLUSTER_NAME=e2e-test
 
 if [ "$(uname)" == "Darwin" ]; then


### PR DESCRIPTION
Fixes already:
* fix invalid backslash in .dockerignore that is failing builds
* fix the `init-container` tests by properly waiting for wiremock to be available before running the decryptor

Missing to make CI pass:
* ~The k8s tests also fail, log lines suggest this may be caused by missing kubectl configuration files (f.e `mv: cannot stat '/home/circleci/.kube/config': No such file or directory`).~
* [kind know issues](https://kind.sigs.k8s.io/docs/user/known-issues/#failure-to-create-cluster-with-cgroups-v2) states that cgroup v2 is only supported on k8s>=1.19. One of the tests in the CI runs k8s 1.18, and the docker environment provided by circleci runs cgroups v2. This explains why 1.18 fails and 1.19&1.20 succeeds.
